### PR TITLE
Add memo support to the ofx parser

### DIFF
--- a/ofx.go
+++ b/ofx.go
@@ -44,6 +44,7 @@ const (
 	transUserDate   nextKey = iota
 	transID         nextKey = iota
 	transDesc       nextKey = iota
+	transMemo       nextKey = iota
 )
 
 type Amount struct {
@@ -62,6 +63,7 @@ func (a *Amount) ParseFromString(s string) error {
 type Transaction struct {
 	Type        TransactionType
 	Description string
+	Memo        string
 	PostedDate  time.Time
 	UserDate    time.Time
 	ID          string
@@ -136,6 +138,8 @@ func Parse(f io.Reader) (*Ofx, error) {
 
 			case "NAME":
 				next = transDesc
+			case "MEMO":
+				next = transMemo
 			}
 
 		case xml.CharData:
@@ -157,6 +161,9 @@ func Parse(f io.Reader) (*Ofx, error) {
 
 			case transDesc:
 				trans.Description = res
+
+			case transMemo:
+				trans.Memo = res
 
 			case transID:
 				trans.ID = res


### PR DESCRIPTION
Some banks uses the name, other use the name and the memo field
to describe a transaction. My current bank uses just the memo field.

So the memo field is very important. Banks implement all incorrectly
OFX files.

http://help.infinitekind.com/discussions/suggestions/1291-support-brain-damaged-ofx-usage-of-name-and-memo